### PR TITLE
Fixed issue that stopped us from opening the Swagger API for the reverse proxy

### DIFF
--- a/reverse-proxy/Program.cs
+++ b/reverse-proxy/Program.cs
@@ -1,11 +1,5 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
-// Add this in ConfigureServices or before app.Run()
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend",
@@ -23,13 +17,6 @@ var configuration = builder.Configuration.GetSection("ReverseProxy");
 builder.Services.AddReverseProxy().LoadFromConfig(configuration);
 
 var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
 
 app.UseHttpsRedirection();
 

--- a/reverse-proxy/appsettings.json
+++ b/reverse-proxy/appsettings.json
@@ -91,6 +91,18 @@
         "Match": {
           "Path": "/rooms/{**catch-all}"
         }
+      },
+      "swagger": {
+        "ClusterId": "badgeur-api",
+        "Match": {
+          "Path": "/swagger/{**catch-all}"
+        }
+      },
+      "swagger-json": {
+        "ClusterId": "badgeur-api",
+        "Match": {
+          "Path": "/swagger/v1/swagger.json"
+        }
       }
     },
     "Clusters": {


### PR DESCRIPTION
Swagger is now once again available at:
http://localhost:8080/swagger/index.html